### PR TITLE
Allow insertion of tasks before existing tasks if there is a gap on the processor

### DIFF
--- a/heft/tests/test_core.py
+++ b/heft/tests/test_core.py
@@ -19,6 +19,11 @@ def commcost(ni, nj, A, B):
     else:
         return 6
 
+def zero_commcost(ni, nj, A, B):
+    """A free commmunication cost function, useful in some tests for simplicity
+    """
+    return 0
+
 dag = {3: (5,),
        4: (6,),
        5: (7,),
@@ -143,18 +148,29 @@ def test_one_agent():
     assert jobson == {i: 'A' for i in (3,4,5,6,7,8,9)}
 
 
-def test_task_insertion():
+def test_task_insertion_at_start():
     dag = {9: (10, 11), # some very high rank tasks which all depend on one
            10: (),      # initial task.
            11: (),
 
-           1: (), # some low rank but cheap tasks
-           2: (),
+           1: (), # one low rank but cheap tasks
           }
 
-    # No communication cost for simplicity
-    def zero_commcost(ni, nj, A, B):
-        return 0
+    orders, _ = schedule(dag, 'ab', compcost, zero_commcost)
+
+    # The cheap task 1 should be done on the spare processor while we are
+    # waiting for task 9 to finish on the first one.
+    assert find_job_event(1, orders).end == 1
+
+
+def test_task_insertion_in_middle():
+    dag = {9: (10, 11), # some very high rank tasks which all depend on one
+           10: (),      # initial task.
+           11: (),
+
+           1: (), # multiple low rank but cheap tasks
+           2: (),
+          }
 
     orders, _ = schedule(dag, 'ab', compcost, zero_commcost)
 

--- a/heft/tests/test_core.py
+++ b/heft/tests/test_core.py
@@ -65,8 +65,8 @@ def test_earliest_finish_time():
     orders = {'a': [Event(2, 0, 3)], 'b': []}
     jobson = {2: 'a'}
     prec = {3: (2,)}
-    assert start_time(3, orders, jobson, prec, commcost, 'a') == 3
-    assert start_time(3, orders, jobson, prec, commcost, 'b') == 3 + 3
+    assert start_time(3, orders, jobson, prec, commcost, compcost, 'a') == 3
+    assert start_time(3, orders, jobson, prec, commcost, compcost, 'b') == 3 + 3
 
 def test_schedule():
     orders, jobson = schedule(dag, 'abc', compcost, commcost)

--- a/heft/tests/test_core.py
+++ b/heft/tests/test_core.py
@@ -174,7 +174,10 @@ def test_task_insertion_in_middle():
 
     orders, _ = schedule(dag, 'ab', compcost, zero_commcost)
 
+    print orders
+    print find_job_event(2, orders)
+
     # Both of the cheap tasks (1 and 2) should be done on the second
     # processor while we are waiting for task 9 to finish on the first one
-    assert find_job_event(1, orders).end == 1
-    assert find_job_event(2, orders).end == 3
+    assert find_job_event(1, orders).end == 3
+    assert find_job_event(2, orders).end == 2

--- a/heft/util.py
+++ b/heft/util.py
@@ -1,4 +1,6 @@
 
+import itertools as it
+
 def reverse_dict(d):
     """ Reverses direction of dependence dict
 
@@ -11,3 +13,8 @@ def reverse_dict(d):
         for val in d[key]:
             result[val] = result.get(val, tuple()) + (key, )
     return result
+
+def find_job_event(job_name, orders_dict):
+    for event in it.chain.from_iterable(orders_dict.values()):
+        if event.job == job_name:
+            return event


### PR DESCRIPTION
Hi,

I was using your code as a basis for my own implementation of HEFT when I noticed that you didn't implement insertion-based scheduling, only scheduling after existing tasks. I've added a test which illustrates the problem and implemented the required changes to the algorithm.

(In the HEFT paper insertion-based scheduling is discussed in section 4.2 just after the heading "Processor Selection Phase".)

P.S. thanks for publishing the code, it was useful for me while I was figuring out how to do my own implementation.
